### PR TITLE
Fixes authentication method to use access_token instead of app_key and app_secret

### DIFF
--- a/drop_sync.rb
+++ b/drop_sync.rb
@@ -3,30 +3,19 @@ require './mecha.rb'
 
 class DropSync
 
-    def initialize(app_key, app_secret)
-        login(app_key, app_secret)
-    end
-
-    def start(filename)
-        download(filename)
-    end
-
-    private
-    def login(app_key, app_secret)
-        web_auth = DropboxOAuth2FlowNoRedirect.new(app_key, app_secret)
-        authorize_url = web_auth.start()
-        system("open", authorize_url)
-        print "Enter the authorization code here: "
-        STDOUT.flush
-        auth_code = STDIN.gets.strip
-        access_token, user_id = web_auth.finish(auth_code)
-        @client = DropboxClient.new(access_token)
+    def initialize(access_token)
+        login(access_token)
     end
 
     def download(filename)
-        url = get_url(filename)
-        Mecha.automatic_download(url)
-        logout
+      url = get_url(filename)
+      Mecha.automatic_download(url)
+      logout
+    end
+
+    private
+    def login(access_token)
+        @client = DropboxClient.new(access_token)
     end
 
     def get_url(filename)

--- a/drop_sync_run.rb
+++ b/drop_sync_run.rb
@@ -1,12 +1,12 @@
 #!/usr/bin/env ruby
 require './drop_sync.rb'
 
-unless ARGV.count == 3
-	puts "Enter your app_key, app_secret and filename"
+unless ARGV.count == 2
+	puts "Enter your access token and filename"
 	raise "Wrong input arguments"
 end
 
-app_key, app_secret, filename = ARGV[0], ARGV[1], ARGV[2]
+access_token, filename = ARGV[0], ARGV[1]
 
-drop = DropSync.new(app_key, app_secret)
-drop.start(filename)
+dropSync = DropSync.new(access_token)
+dropSync.download(filename)


### PR DESCRIPTION
# **Context**

The browser opens everytime that the user runs the script. We need to automise the access_token logic.

# **Code description**

I refactor the code to use access_token generated in Dropbox Developers website, instead of app_key and app_secret.

# **How to test**

Just run the script passing the access_token generated in Dropbox Developers website and the name of the folder.